### PR TITLE
documented get_bmi function with Roxygen2 syntax

### DIFF
--- a/R/baxter.R
+++ b/R/baxter.R
@@ -49,9 +49,22 @@ get_metadata <- function() {
     return(baxter_metadata)
 }
 
+#' Returns an individuals body mass index, given metric units.
+#'
+#' The squared value of weight in kilograms
+#' divided by height in meters, which is 
+#' converted by dividing cm by 100.
+#'
+#' @param weight_kg Weight in kilograms, a number.
+#' @param height_cm Height in centimeters, a number.
+#' @return The BMI of a given individual, a number.
+#' @examples 
+#' get_bmi(80, 182)
+#' get_bmi(50, 160)
 get_bmi <- function(weight_kg, height_cm){
     return(weight_kg / (height_cm/100) ^ 2)
-}
+} #consider adding an error for 0 value entries to either param
+
 
 get_bmi_category <- function(weight_kg, height_cm){
     bmi <- get_bmi(weight_kg, height_cm)


### PR DESCRIPTION
We documented the `get_bmi` function and made a suggestion to incorporate an error message for zero value numbers.